### PR TITLE
Pin the node_redis version because a newer version has broken compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       , "cookie": "0.0.x"
       , "jade": "*"
       , "socket.io": ">=0.9.7"
-      , "redis": ">= 0.7.2"
+      , "redis": "0.7.2"
       , "connect-redis": "1.4.x"
       , "passport": "0.1.x"
       , "passport-twitter": "0.1.x"


### PR DESCRIPTION
The calls to `hmset` complain that not all values are strings when using new versions of the `redis` npm package.
