### PR TITLE
Reverted to redis 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       , "cookie": "0.0.x"
       , "jade": "*"
       , "socket.io": ">=0.9.7"
-      , "redis": "0.8.x"
+      , "redis": "0.7.2"
       , "connect-redis": "1.4.x"
       , "passport": "0.1.x"
       , "passport-twitter": "0.1.x"


### PR DESCRIPTION
0.8.x causes a `hmset expected value to be a string` error.
