### PR TITLE
Can't finish the installation steps since Callback URL config info is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,18 @@ If you have these 2 tools installed, go to terminal and type:
 
 Then, edit config.json with your favorite text editor and add Facebook & Twitter keys.
 
-To allow Sign In with Twitter: [Create a new application](https://dev.twitter.com/apps/new) and copy 
-the keys that Twitter gives you into 'config.json'.
+To allow Sign In with Twitter: 
 
-To allow Sign In with Facebook: [Create a new application](https://developers.facebook.com/apps) and copy the keys Facebook gives you into 'config.json'
+- [Create a new application](https://dev.twitter.com/apps/new) and copy the keys that Twitter gives you into 'config.json'. 
+
+- Go to your Twitter app Settings and add the Callback URL contained in 'config.json': http://127.0.0.1:6789/auth/twitter/callback
+
+To allow Sign In with Facebook:
+
+- [Create a new application](https://developers.facebook.com/apps) and copy the keys Facebook gives you into 'config.json'.
+
+- Go to your Facebook app Settings/Basic, click on Website with Facebook Login and add the Callback URL contained in 'config.json':
+http://127.0.0.1:6789/auth/facebook/callback
 
 Go to terminal and run `node balloons`.
 


### PR DESCRIPTION
When following the installation info I found two problems.

If I try to log in with Twitter I get this exception:

Error: failed to find request token in session
    at Strategy.OAuthStrategy.authenticate (/home/ffernandez/IdeaProjects/Balloons.IO/node_modules/passport-twitter/node_modules/passport-oauth/lib/passport-oauth/strategies/oauth.js:122:54)

To solve it I had to go to my Twitter app Settings and add the Callback URL contained in 'config.json': http://127.0.0.1:6789/auth/twitter/callback

If I try to log in with Facebook I get this one:

An error occurred. Please try again later.

API Error Code: 191
API Error Description: The specified URL is not owned by the application
Error Message: Invalid redirect_uri: Given URL is not allowed by the Application configuration.

To solve it I had to go to my Facebook app Settings/Basic, click on Website with Facebook Login and add the Callback URL contained in 'config.json': http://127.0.0.1:6789/auth/facebook/callback

These steps should be included in the Installation info to achieve a soft landing in the app.
