### PR TITLE
Add redis-backed chat history with setup in config

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -18,6 +18,9 @@
   "app": {
     "port": 6789
   },
+  "history": {
+    "viewlimit": 5
+  },
   "theme": {
     "name" : "default"
   }

--- a/sockets.js
+++ b/sockets.js
@@ -72,6 +72,7 @@ function Sockets (app, server) {
       // Chat Log handler
       , chatlogFileName = './chats/' + room_id + (now.getFullYear()) + (now.getMonth() + 1) + (now.getDate()) + ".txt"
       // , chatlogWriteStream = fs.createWriteStream(chatlogFileName, {'flags': 'a'});
+      , chatlogKey = 'chats:' + room_id;
 
     socket.join(room_id);
 
@@ -104,6 +105,9 @@ function Sockets (app, server) {
         }
 
         // chatlogWriteStream.write(JSON.stringify(chatlogRegistry) + "\n");
+        if(config.history) {
+          client.lpush(chatlogKey, JSON.stringify(chatlogRegistry))
+        }
         
         io.sockets.in(room_id).emit('new msg', {
           nickname: nickname,
@@ -126,22 +130,19 @@ function Sockets (app, server) {
     });
 
     socket.on('history request', function() {
-      var history = [];
-      var tail = require('child_process').spawn('tail', ['-n', 5, chatlogFileName]);
-      tail.stdout.on('data', function (data) {
-        var lines = data.toString('utf-8').split("\n");
-        
-        lines.forEach(function(line, index) {
-          if(line.length) {
-            var historyLine = JSON.parse(line);
-            history.push(historyLine);
-          }
-        });
+      if(config.history) {
+        var history = [];
+        client.lrange(chatlogKey,0,(config.history.viewlimit || 5)-1,function (err, lines) {
+          lines.forEach(function(line) {
+              var historyLine = JSON.parse(line);
+              history.unshift(historyLine);
+          });
 
-        socket.emit('history response', {
-          history: history
+          socket.emit('history response', {
+            history: history
+          });
         });
-      });
+      }
     });
 
     socket.on('disconnect', function() {


### PR DESCRIPTION
I implemented a history with Redis. It uses Redis lists with the chatroom id as the key. It keeps unlimited history in Redis, but only pulls from Redis the last 5 chat lines unless a higher/lower 'viewlimit' is set in the config file. The history is not saved in Redis or displayed unless there is a history entry in the config file.
