### PR TITLE
Add config.session.age in millaseconds. Default 0.

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -14,6 +14,7 @@
   },
   "session" : {
     "secret" : "yourbestsecret"
+    "age" : 0
   },
   "app": {
     "port": 6789

--- a/config/index.js
+++ b/config/index.js
@@ -91,7 +91,10 @@ function Config (app) {
   log('Use of express session middleware.');
   app.use(express.session({
     key: "balloons",
-    store: app.get('sessionStore')
+    store: app.get('sessionStore'),
+    cookie: {
+        maxAge: config.session.age || null
+    }
   }));
   
   log('Use of passport middlewares.');


### PR DESCRIPTION
This allows configuration of the length of sessions. For our install we wanted to load the chat room on a Chrome startup tab without having to login. We set it to '31536000000' for a year-long session. Sample config sets it as session. No specification will also set it as session.
