### PR TITLE
Fix missing comma for json sample config.

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -13,7 +13,7 @@
     }
   },
   "session" : {
-    "secret" : "yourbestsecret"
+    "secret" : "yourbestsecret",
     "age" : 0
   },
   "app": {


### PR DESCRIPTION
Sample.json not parsing from missing comma before session age.
