### PR TITLE
Stop defaults in env.js overriding config.json values

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -23,12 +23,12 @@ module.exports = {
     }
   },
   session: {
-    secret: env.SESSION_SECRET || "b.io:secret"
+    secret: env.SESSION_SECRET
   },
   app: {
-    port: env.PORT || 6789
+    port: env.PORT
   },
   theme: {
-    name: env.THEME_NAME || "default"
+    name: env.THEME_NAME
   }
 };


### PR DESCRIPTION
The settings session:secret, app:port and theme:name set in the config.json are never used because the defaults in env.js override the values. This fix allows for these values to be set with ENV variables or in config.json. (e.g. setting the port). ENV values still override config.json values for settings. Defaults are required in config.json.
