### PR TITLE
Gitignore custom themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ chats/*
 *.rdb
 !views/themes/default
 views/themes/*
+public/custom


### PR DESCRIPTION
This change allows people to use local themes, css, js, and images without having git attempt to track the files.
